### PR TITLE
Disable tests on too old python

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -17,8 +17,10 @@ include /usr/share/dpkg/default.mk
 # package maintainers to append LDFLAGS
 #export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
+# require IsolatedAsyncioTestCase that is in python >= 3.8
+export PYBUILD_DISABLE_python3.6=test
+export PYBUILD_DISABLE_python3.7=test
 
 # main packaging script based on dh7 syntax
 %:
 	dh $@ --with python3 --buildsystem=pybuild
-


### PR DESCRIPTION
Tests use IsolatedAsyncioTestCase which is in python >= 3.8